### PR TITLE
Added support for the command line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,10 @@ hs_err_pid*
 replay_pid*
 
 target/
+.vscode/
+.idea/
+.settings/
+bin/
+
+.classpath
+.project

--- a/analyzer-config.json
+++ b/analyzer-config.json
@@ -3,6 +3,12 @@
         "checks": [
             {
                 "name": "UnderscoreName"
+            },
+            {
+                "name": "AsteriskImport"
+            },
+            {
+                "name": "LineLength"
             }
         ]
     }

--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,9 @@
     <groupId>com.github.cluelessskywatcher</groupId>
     <artifactId>lentil</artifactId>
     <version>1.0-SNAPSHOT</version>
-
+    <packaging>jar</packaging>
     <name>lentil</name>
-    <description>A simple lentil.</description>
+    <description>A static code analyzer for Java</description>
     <!-- FIXME change it to the project's website -->
     <url>http://www.example.com</url>
 
@@ -47,7 +47,17 @@
             <artifactId>json-simple</artifactId>
             <version>1.1.1</version>
         </dependency>
-
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>4.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <version>3.4.2</version>
+            <type>maven-plugin</type>
+        </dependency>
     </dependencies>
 
     <build>
@@ -91,6 +101,29 @@
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>2.8.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <configuration>
+                        <descriptorRefs>
+                            <descriptorRef>jar-with-dependencies</descriptorRef>
+                        </descriptorRefs>
+                        <archive>
+                            <manifest>
+                                <mainClass>com.github.cluelessskywatcher.lentil.LentilMain</mainClass>
+                            </manifest>
+                        </archive>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>make-assembly</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>single</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/src/main/java/com/github/cluelessskywatcher/lentil/LentilCmdLineRunner.java
+++ b/src/main/java/com/github/cluelessskywatcher/lentil/LentilCmdLineRunner.java
@@ -1,0 +1,36 @@
+package com.github.cluelessskywatcher.lentil;
+
+import java.text.MessageFormat;
+
+import com.github.cluelessskywatcher.lentil.report.LentilRunner;
+
+import picocli.CommandLine;
+
+public class LentilCmdLineRunner implements Runnable {
+    @CommandLine.Parameters(index = "0", description = "File to execute the runner on")
+    private String filePath;
+
+    @CommandLine.Option(names = {"-c", "--config"}, description = "Configuration file for the checker. By default it is analyzer-config.json")
+    private String configFilePath;
+
+    @Override
+    public void run() {
+        // TODO Auto-generated method stub
+        try {
+            LentilRunner runner;
+            if (configFilePath != null){
+                runner = new LentilRunner(filePath, configFilePath);
+            }
+            else {
+                runner = new LentilRunner(filePath);
+            }
+            System.out.println(MessageFormat.format("{0} issues found", runner.getReports().size()));
+            for (String report : runner.getReports()){
+                System.out.println(report);
+            }
+        } 
+        catch (Exception e){
+            e.printStackTrace();
+        }           
+    }    
+}

--- a/src/main/java/com/github/cluelessskywatcher/lentil/LentilMain.java
+++ b/src/main/java/com/github/cluelessskywatcher/lentil/LentilMain.java
@@ -1,14 +1,9 @@
 package com.github.cluelessskywatcher.lentil;
 
-import com.github.cluelessskywatcher.lentil.report.LentilRunner;
+import picocli.CommandLine;
 
 public class LentilMain {
-    private static final String FILE_PATH = 
-        "src/main/java/com/github/cluelessskywatcher/lentil/samples/UnderscoreNameExample.java";
     public static void main(String[] args) throws Exception{
-        LentilRunner runner = new LentilRunner(FILE_PATH);
-        for (String report : runner.getReports()){
-            System.out.println(report);
-        }
+        new CommandLine(new LentilCmdLineRunner()).execute(args);
     }
 }

--- a/src/main/java/com/github/cluelessskywatcher/lentil/samples/AsteriskImportExample.java
+++ b/src/main/java/com/github/cluelessskywatcher/lentil/samples/AsteriskImportExample.java
@@ -1,8 +1,8 @@
 package com.github.cluelessskywatcher.lentil.samples;
 
-import java.util.*; // Violation
+import java.util.*;
 import java.awt.color.CMMException;
-import java.awt.geom.*; // Violation
+import java.awt.geom.*;
 
 public class AsteriskImportExample {
     int x = 5;


### PR DESCRIPTION
Solves #1 

In order to run from the command line, run
`java -jar target/lentil-1.0-SNAPSHOT-jar-with-dependencies.jar <file name>.java`

If you wish to use a custom config file specified in a different directory, use the "-c" option
`java -jar target/lentil-1.0-SNAPSHOT-jar-with-dependencies.jar <file name> -c <config file name>.json`